### PR TITLE
Update Dashboard and PerplexityValidationService for Australian/NZ receipts

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -717,7 +717,7 @@ const Dashboard: React.FC<DashboardProps> = ({ onSignOut, onShowReceiptScanning,
           </p>
           <div className="text-sm text-text-secondary space-y-1 max-w-sm mx-auto">
             <p>• "How much did I spend on electronics?"</p>
-            <p>• "Show me all Apple receipts from 2023"</p>
+            <p>• "Show me all Apple receipts from 2024"</p>
             <p>• "What warranties expire soon?"</p>
           </div>
         </div>

--- a/src/services/ragService.ts
+++ b/src/services/ragService.ts
@@ -162,12 +162,19 @@ export class RAGService {
    * Get system prompt based on query type
    */
   private static getSystemPrompt(queryType: 'search' | 'summary' | 'question'): string {
+    const currentDate = new Date().toLocaleDateString('en-US', { 
+      year: 'numeric', 
+      month: 'long', 
+      day: 'numeric' 
+    });
+    
     const basePrompt = `You are a helpful assistant that answers questions about receipt data. You should:
 - Only use the receipt data provided to answer questions
 - Be concise and accurate
 - If you can't answer based on the provided data, say so
 - Format monetary amounts clearly (e.g., $123.45)
-- Use bullet points or tables when appropriate`;
+- Use bullet points or tables when appropriate
+- IMPORTANT: Today's date is ${currentDate}. Use this date for all warranty calculations and time-based queries`;
 
     switch (queryType) {
       case 'summary':


### PR DESCRIPTION
Update Dashboard and PerplexityValidationService for Australian/NZ receipts
- Changed example query in Dashboard to reflect 2024 instead of 2023.
- Enhanced PerplexityValidationService to validate receipt data specifically for Australian and New Zealand receipts, including checks for store names and purchase locations.
- Updated prompts for AI validation to include context relevant to AU/NZ markets.
- Added a new method to determine if a receipt is from Australia or New Zealand based on various indicators.