### PR TITLE
feat: add profile navigation to ReceiptScanning and MyLibrary components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -136,6 +136,7 @@ const AppContent: React.FC = () => {
           <ReceiptScanning
             onBackToDashboard={() => window.location.href = '/dashboard'}
             onReceiptSaved={handleReceiptSaved}
+            onShowProfile={() => window.location.href = '/profile'}
           />
         ) : (
           <Navigate to="/login" replace />

--- a/src/components/MyLibrary.tsx
+++ b/src/components/MyLibrary.tsx
@@ -706,8 +706,7 @@ const MyLibrary: React.FC<MyLibraryProps> = ({ onBackToDashboard, onShowReceiptS
                     </div>
                     <button
                       onClick={() => {
-                        // Navigate to profile settings - for now using onBackToDashboard as placeholder
-                        onBackToDashboard();
+                        onShowProfile ? onShowProfile() : onBackToDashboard();
                         setShowUserMenu(false);
                       }}
                       className="w-full text-left px-4 py-2 text-sm text-text-secondary hover:bg-gray-100 hover:text-text-primary transition-colors duration-200 flex items-center space-x-2"

--- a/src/components/ReceiptScanning.tsx
+++ b/src/components/ReceiptScanning.tsx
@@ -41,6 +41,7 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs
 interface ReceiptScanningProps {
   onBackToDashboard: () => void;
   onReceiptSaved?: (receiptId: string) => void;
+  onShowProfile?: () => void;
 }
 
 // Use the imported type instead of local interface
@@ -49,7 +50,7 @@ type ExtractedData = ExtractedReceiptData;
 type CaptureMode = 'normal' | 'long';
 type InputMode = 'capture' | 'upload' | 'manual';
 
-const ReceiptScanning: React.FC<ReceiptScanningProps> = ({ onBackToDashboard, onReceiptSaved }) => {
+const ReceiptScanning: React.FC<ReceiptScanningProps> = ({ onBackToDashboard, onReceiptSaved, onShowProfile }) => {
   const { user, profilePicture } = useUser();
   const { subscriptionInfo } = useSubscription();
   const [inputMode, setInputMode] = useState<InputMode>('capture');
@@ -885,8 +886,7 @@ const ReceiptScanning: React.FC<ReceiptScanningProps> = ({ onBackToDashboard, on
               {/* Settings Button */}
               <button
                 onClick={() => {
-                  // Navigate to profile settings - for now using onBackToDashboard as placeholder
-                  onBackToDashboard();
+                  onShowProfile ? onShowProfile() : onBackToDashboard();
                 }}
                 className="p-2 text-text-secondary hover:text-text-primary transition-colors duration-200"
                 title="Settings"
@@ -929,8 +929,7 @@ const ReceiptScanning: React.FC<ReceiptScanningProps> = ({ onBackToDashboard, on
                     </div>
                     <button
                       onClick={() => {
-                        // Navigate to profile settings - for now using onBackToDashboard as placeholder
-                        onBackToDashboard();
+                        onShowProfile ? onShowProfile() : onBackToDashboard();
                         setShowUserMenu(false);
                       }}
                       className="w-full text-left px-4 py-2 text-sm text-text-secondary hover:bg-gray-100 hover:text-text-primary transition-colors duration-200 flex items-center space-x-2"


### PR DESCRIPTION
- Implemented onShowProfile callback in ReceiptScanning and MyLibrary components to enable navigation to the profile page.
- Updated button functionality to conditionally navigate to the profile or dashboard based on the presence of the onShowProfile prop.