### PR TITLE
feat(ReceiptScanning): add profile navigation functionality

### DIFF
--- a/src/components/ReceiptScanning.tsx
+++ b/src/components/ReceiptScanning.tsx
@@ -39,6 +39,7 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs
 
 interface ReceiptScanningProps {
   onBackToDashboard: () => void;
+  onShowProfile: () => void;
   onReceiptSaved?: (receiptId: string) => void;
 }
 
@@ -48,7 +49,7 @@ type ExtractedData = ExtractedReceiptData;
 type CaptureMode = 'normal' | 'long';
 type InputMode = 'capture' | 'upload' | 'manual';
 
-const ReceiptScanning: React.FC<ReceiptScanningProps> = ({ onBackToDashboard, onReceiptSaved }) => {
+const ReceiptScanning: React.FC<ReceiptScanningProps> = ({ onBackToDashboard, onShowProfile, onReceiptSaved }) => {
   const { user, profilePicture } = useUser();
   const { subscriptionInfo } = useSubscription();
   const [inputMode, setInputMode] = useState<InputMode>('capture');
@@ -952,8 +953,7 @@ const ReceiptScanning: React.FC<ReceiptScanningProps> = ({ onBackToDashboard, on
                     </div>
                     <button
                       onClick={() => {
-                        // Navigate to profile settings - for now using onBackToDashboard as placeholder
-                        onBackToDashboard();
+                        onShowProfile();
                         setShowUserMenu(false);
                       }}
                       className="w-full text-left px-4 py-2 text-sm text-text-secondary hover:bg-gray-100 hover:text-text-primary transition-colors duration-200 flex items-center space-x-2"


### PR DESCRIPTION
- Introduced a new prop, onShowProfile, to enable navigation to the user profile from the ReceiptScanning component.
- Updated the button click handler to call onShowProfile instead of onBackToDashboard, enhancing user interaction options.